### PR TITLE
 Lower version constraint for doctrine/annotations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "symfony/dependency-injection": "~2.7|~3.0|~4.0",
         "nyholm/symfony-bundle-test": "^1.2",
         "phpunit/phpunit": "^6.4",
-        "doctrine/annotations": "^1.5",
+        "doctrine/annotations": "^1.4",
         "jms/metadata": "^1.6",
         "fzaninotto/faker": "^1.7",
         "doctrine/orm": "^2.5"


### PR DESCRIPTION
... to support PHP 7.0.x